### PR TITLE
Appwrapper invalid template failure fix.  Updated to V1.17.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR=_output/bin
-RELEASE_VER=v1.16
+RELEASE_VER=v1.17
 CURRENT_DIR=$(shell pwd)
 #MCAD_REGISTRY=$(shell docker ps --filter name=mcad-registry | grep -v NAME)
 #LOCAL_HOST_NAME=localhost

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -77,7 +77,7 @@ function kind-up-cluster {
 
 # clean up
 function cleanup {
-    echo "Cleaning up..."
+    echo "==========================>>>>> Cleaning up... <<<<<=========================="
     echo " "
 
     echo "Custom Resource Definitions..."
@@ -104,7 +104,7 @@ function cleanup {
     kind delete cluster ${CLUSTER_CONTEXT}
 }
 
-function kube-batch-up {
+function kube-test-env-up {
     cd ${ROOT_DIR}
 
     export KUBECONFIG="$(kind get kubeconfig-path ${CLUSTER_CONTEXT})"
@@ -165,9 +165,9 @@ trap cleanup EXIT
 
 kind-up-cluster
 
-kube-batch-up
+kube-test-env-up
 
 cd ${ROOT_DIR}
 
-echo "Running E2E tests..."
+echo "==========================>>>>> Running E2E tests... <<<<<=========================="
 go test ./test/e2e -v -timeout 30m

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -432,7 +432,7 @@ func GetPodTemplate(qjobRes *arbv1.AppWrapperResource) (*v1.PodTemplateSpec, err
 
 	template, ok := obj.(*v1.PodTemplate)
 	if !ok {
-		return nil, fmt.Errorf("Queuejob resource template not define a Pod")
+		return nil, fmt.Errorf("Resource template not define a PodTemplate")
 	}
 
 	return &template.Template, nil

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -432,7 +432,7 @@ func GetPodTemplate(qjobRes *arbv1.AppWrapperResource) (*v1.PodTemplateSpec, err
 
 	template, ok := obj.(*v1.PodTemplate)
 	if !ok {
-		return nil, fmt.Errorf("Resource template not define a PodTemplate")
+		return nil, fmt.Errorf("Resource template not define as a PodTemplate")
 	}
 
 	return &template.Template, nil

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -556,7 +556,7 @@ func (qjrPod *QueueJobResPod) GetAggregatedResources(job *arbv1.AppWrapper) *clu
                 if ar.Type == arbv1.ResourceTypePod {
 					template, err := qjrPod.GetPodTemplate(&ar)
 					if err != nil {
-						glog.Errorf("Pod Template not found in item: %+v error: %+v.  Aggregated resources set to 0.", ar, err)
+						glog.Errorf("Can not parse pod template in item: %+v error: %+v.  Aggregated resources set to 0.", ar, err)
 					} else {
 						replicas := ar.Replicas
 						myres := queuejobresources.GetPodResources(template)
@@ -593,7 +593,7 @@ func (qjrPod *QueueJobResPod) createQueueJobPod(qj *arbv1.AppWrapper, ix int32, 
 	templateCopy, err := qjrPod.GetPodTemplate(qjobRes)
 
 	if err != nil {
-		glog.Errorf("Cannot parse pod template for QJ")
+		glog.Errorf("Can not parse pod template in job: %+v, item: %+v error: %+v.", qj, qjobRes, err)
 		return nil
 	}
 	podName := fmt.Sprintf("%s-%d-%s", qj.Name, ix, generateUUID())

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -554,14 +554,19 @@ func (qjrPod *QueueJobResPod) GetAggregatedResources(job *arbv1.AppWrapper) *clu
             //calculate scaling
             for _, ar := range job.Spec.AggrResources.Items {
                 if ar.Type == arbv1.ResourceTypePod {
-			template, _ := qjrPod.GetPodTemplate(&ar)
-			replicas := ar.Replicas
-			myres := queuejobresources.GetPodResources(template)
-                        myres.MilliCPU = float64(replicas) * myres.MilliCPU
-                        myres.Memory = float64(replicas) * myres.Memory
-                        myres.GPU = int64(replicas) * myres.GPU
-                        total = total.Add(myres)
-		}
+					template, err := qjrPod.GetPodTemplate(&ar)
+					if err != nil {
+						glog.Errorf("Pod Template not found in item: %+v error: %+v.  Aggregated resources set to 0.", ar, err)
+					} else {
+						replicas := ar.Replicas
+						myres := queuejobresources.GetPodResources(template)
+
+						myres.MilliCPU = float64(replicas) * myres.MilliCPU
+						myres.Memory = float64(replicas) * myres.Memory
+						myres.GPU = int64(replicas) * myres.GPU
+						total = total.Add(myres)
+					}
+				}
             }
         }
         return total

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -420,7 +420,7 @@ func (qjrPod *QueueJobResPod) manageQueueJobPods(activePods []*v1.Pod, succeeded
 								// Failed to create Pod, wait a moment and then create it again
 								// This is to ensure all pods under the same QueueJob created
 								// So gang-scheduling could schedule the QueueJob successfully
-								glog.Warningf("Failed to create pod %s for QueueJob %s, err %#v, wait 2 seconds and re-create it", newPod.Name, qj.Name, err)
+								glog.Warningf("Failed to create pod %s for Job %s, err %#v, wait 2 seconds and re-create it", newPod.Name, qj.Name, err)
 								time.Sleep(2 * time.Second)
 							}
 						}
@@ -592,7 +592,7 @@ func (qjrPod *QueueJobResPod) GetAggregatedResourcesByPriority(priority int, job
 		  	if ar.Type == arbv1.ResourceTypePod {
 		  		template, err := qjrPod.GetPodTemplate(&ar)
 		  		if err != nil {
-		  			glog.Errorf("Can not parse pod template in item: %+v error: %+v.  Aggregated resources set to 0.", ar, err)
+		  			glog.Errorf("Cannot parse pod template in item: %+v error: %+v.  Aggregated resources set to 0.", ar, err)
 		  		} else {
 					total = total.Add(queuejobresources.GetPodResources(template))
 		  		}
@@ -606,7 +606,7 @@ func (qjrPod *QueueJobResPod) createQueueJobPod(qj *arbv1.AppWrapper, ix int32, 
 	templateCopy, err := qjrPod.GetPodTemplate(qjobRes)
 
 	if err != nil {
-		glog.Errorf("Can not parse PodTemplate in job: %+v, item: %+v error: %+v.", qj, qjobRes, err)
+		glog.Errorf("Cannot parse PodTemplate in job: %+v, item: %+v error: %+v.", qj, qjobRes, err)
 		return nil
 	}
 	podName := fmt.Sprintf("%s-%d-%s", qj.Name, ix, generateUUID())

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -302,14 +302,22 @@ func (qjrPod *QueueJobResPod) manageQueueJob(qj *arbv1.AppWrapper, pods []*v1.Po
 			go func(ix int32) {
 				defer wait.Done()
 				newPod := qjrPod.createQueueJobPod(qj, ix, ar)
-				_, err := qjrPod.clients.Core().Pods(newPod.Namespace).Create(newPod)
-				if err != nil {
-					// Failed to create Pod, wait a moment and then create it again
-					// This is to ensure all pods under the same QueueJob created
-					// So gang-scheduling could schedule the QueueJob successfully
+
+				if newPod == nil {
+					err := fmt.Errorf("Job resource template item not define as a PodTemplate")
 					glog.Errorf("Failed to create pod %s for QueueJob %s, err %#v",
 						newPod.Name, qj.Name, err)
 					errs = append(errs, err)
+				} else {
+					_, err := qjrPod.clients.Core().Pods(newPod.Namespace).Create(newPod)
+					if err != nil {
+						// Failed to create Pod, wait a moment and then create it again
+						// This is to ensure all pods under the same QueueJob created
+						// So gang-scheduling could schedule the QueueJob successfully
+						glog.Errorf("Failed to create pod %s for QueueJob %s, err %#v",
+							newPod.Name, qj.Name, err)
+						errs = append(errs, err)
+					}
 				}
 			}(i)
 		}
@@ -399,18 +407,23 @@ func (qjrPod *QueueJobResPod) manageQueueJobPods(activePods []*v1.Pod, succeeded
 				go func(ix int32) {
 					defer wait.Done()
 					newPod := qjrPod.createQueueJobPod(qj, ix, ar)
-					//newPod := buildPod(fmt.Sprintf("%s-%d-%s", qj.Name, ix, generateUUID()), qj.Namespace, qj.Spec.Template, []metav1.OwnerReference{*metav1.NewControllerRef(qj, controllerKind)}, ix)
-					for {
-						_, err := qjrPod.clients.Core().Pods(newPod.Namespace).Create(newPod)
-						if err == nil {
-							// Create Pod successfully
-							break
-						} else {
-							// Failed to create Pod, wait a moment and then create it again
-							// This is to ensure all pods under the same QueueJob created
-							// So gang-scheduling could schedule the QueueJob successfully
-							glog.Warningf("Failed to create pod %s for QueueJob %s, err %#v, wait 2 seconds and re-create it", newPod.Name, qj.Name, err)
-							time.Sleep(2 * time.Second)
+					if newPod == nil {
+						err = fmt.Errorf("Job resource template item not define as a PodTemplate")
+						glog.Errorf("Failed to create pod %s for Job %s, err %#v",
+							newPod.Name, qj.Name, err)
+					} else {
+						for {
+							_, err := qjrPod.clients.Core().Pods(newPod.Namespace).Create(newPod)
+							if err == nil {
+								// Create Pod successfully
+								break
+							} else {
+								// Failed to create Pod, wait a moment and then create it again
+								// This is to ensure all pods under the same QueueJob created
+								// So gang-scheduling could schedule the QueueJob successfully
+								glog.Warningf("Failed to create pod %s for QueueJob %s, err %#v, wait 2 seconds and re-create it", newPod.Name, qj.Name, err)
+								time.Sleep(2 * time.Second)
+							}
 						}
 					}
 				}(i)
@@ -528,8 +541,6 @@ func (qjrPod *QueueJobResPod) GetPodTemplate(qjobRes *arbv1.AppWrapperResource) 
 
 	podGVK := schema.GroupVersion{Group: v1.GroupName, Version: "v1"}.WithKind("PodTemplate")
 
-	glog.Errorf("Pod resource not found in Pod Template: %+v.  Aggregated resources set to 0.", qjobRes)
-
 	obj, _, err := qjrPod.jsonSerializer.Decode(qjobRes.Template.Raw, &podGVK, nil)
 	if err != nil {
 		return nil, err
@@ -537,10 +548,8 @@ func (qjrPod *QueueJobResPod) GetPodTemplate(qjobRes *arbv1.AppWrapperResource) 
 
 	template, ok := obj.(*v1.PodTemplate)
 	if !ok {
-		return nil, fmt.Errorf("Job resource template not define a Pod")
+		return nil, fmt.Errorf("Job resource template item not define as a PodTemplate")
 	}
-
-	glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
 
 	return &template.Template, nil
 
@@ -573,32 +582,37 @@ func (qjrPod *QueueJobResPod) GetAggregatedResources(job *arbv1.AppWrapper) *clu
 }
 
 func (qjrPod *QueueJobResPod) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
-        total := clusterstateapi.EmptyResource()
-        if job.Spec.AggrResources.Items != nil {
-            //calculate scaling
-            for _, ar := range job.Spec.AggrResources.Items {
-		  if ar.Priority < float64(priority) {
-		  	continue
-		  }
-                  if ar.Type == arbv1.ResourceTypePod {
-                         template, _ := qjrPod.GetPodTemplate(&ar)
-			 total = total.Add(queuejobresources.GetPodResources(template))
-                }
-            }
-        }
-        return total
+	total := clusterstateapi.EmptyResource()
+	if job.Spec.AggrResources.Items != nil {
+		//calculate scaling
+		for _, ar := range job.Spec.AggrResources.Items {
+			if ar.Priority < float64(priority) {
+		  		continue
+		  	}
+
+		  	if ar.Type == arbv1.ResourceTypePod {
+		  		template, err := qjrPod.GetPodTemplate(&ar)
+		  		if err != nil {
+		  			glog.Errorf("Can not parse pod template in item: %+v error: %+v.  Aggregated resources set to 0.", ar, err)
+		  		} else {
+					total = total.Add(queuejobresources.GetPodResources(template))
+		  		}
+		  	}
+		}
+	}
+	return total
 }
 
 func (qjrPod *QueueJobResPod) createQueueJobPod(qj *arbv1.AppWrapper, ix int32, qjobRes *arbv1.AppWrapperResource) *corev1.Pod {
 	templateCopy, err := qjrPod.GetPodTemplate(qjobRes)
 
 	if err != nil {
-		glog.Errorf("Can not parse pod template in job: %+v, item: %+v error: %+v.", qj, qjobRes, err)
+		glog.Errorf("Can not parse PodTemplate in job: %+v, item: %+v error: %+v.", qj, qjobRes, err)
 		return nil
 	}
 	podName := fmt.Sprintf("%s-%d-%s", qj.Name, ix, generateUUID())
 
-	glog.Infof("I have template copy for the pod %+v", templateCopy)
+	glog.Infof("Template copy for the pod %+v", templateCopy)
 
 	tmpl := templateCopy.Labels
 

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -305,8 +305,7 @@ func (qjrPod *QueueJobResPod) manageQueueJob(qj *arbv1.AppWrapper, pods []*v1.Po
 
 				if newPod == nil {
 					err := fmt.Errorf("Job resource template item not define as a PodTemplate")
-					glog.Errorf("Failed to create pod %s for QueueJob %s, err %#v",
-						newPod.Name, qj.Name, err)
+					glog.Errorf("Failed to create a pod for Job %s, error: %#v.", qj.Name, err)
 					errs = append(errs, err)
 				} else {
 					_, err := qjrPod.clients.Core().Pods(newPod.Namespace).Create(newPod)

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -528,6 +528,8 @@ func (qjrPod *QueueJobResPod) GetPodTemplate(qjobRes *arbv1.AppWrapperResource) 
 
 	podGVK := schema.GroupVersion{Group: v1.GroupName, Version: "v1"}.WithKind("PodTemplate")
 
+	glog.Errorf("Pod resource not found in Pod Template: %+v.  Aggregated resources set to 0.", qjobRes)
+
 	obj, _, err := qjrPod.jsonSerializer.Decode(qjobRes.Template.Raw, &podGVK, nil)
 	if err != nil {
 		return nil, err
@@ -535,8 +537,10 @@ func (qjrPod *QueueJobResPod) GetPodTemplate(qjobRes *arbv1.AppWrapperResource) 
 
 	template, ok := obj.(*v1.PodTemplate)
 	if !ok {
-		return nil, fmt.Errorf("Queuejob resource template not define a Pod")
+		return nil, fmt.Errorf("Job resource template not define a Pod")
 	}
+
+	glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
 
 	return &template.Template, nil
 

--- a/pkg/controller/queuejobresources/utils.go
+++ b/pkg/controller/queuejobresources/utils.go
@@ -35,8 +35,6 @@ func GetPodResources(template *v1.PodTemplateSpec) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         req := clusterstateapi.EmptyResource()
         limit := clusterstateapi.EmptyResource()
-        glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
-
         spec := template.Spec
 
         if &spec == nil {

--- a/pkg/controller/queuejobresources/utils.go
+++ b/pkg/controller/queuejobresources/utils.go
@@ -35,14 +35,14 @@ func GetPodResources(template *v1.PodTemplateSpec) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         req := clusterstateapi.EmptyResource()
         limit := clusterstateapi.EmptyResource()
+        glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
+
         spec := template.Spec
 
         if &spec == nil {
             glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
             return total
         }
-
-        glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
 
         for _, c := range template.Spec.Containers {
             req.Add(clusterstateapi.NewResource(c.Resources.Requests))

--- a/pkg/controller/queuejobresources/utils.go
+++ b/pkg/controller/queuejobresources/utils.go
@@ -41,6 +41,9 @@ func GetPodResources(template *v1.PodTemplateSpec) *clusterstateapi.Resource {
             glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
             return total
         }
+
+        glog.Errorf("Pod Spec not found in Pod Template: %+v.  Aggregated resources set to 0.", template)
+
         for _, c := range template.Spec.Containers {
             req.Add(clusterstateapi.NewResource(c.Resources.Requests))
             limit.Add(clusterstateapi.NewResource(c.Resources.Limits))

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -42,7 +42,7 @@ var _ = Describe("Predicates E2E Test", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)
 
-		aw := createPodTemplateAW(context,"aw-podtemplate-2")
+		aw := createBadPodTemplateAW(context,"aw-podtemplate-2")
 
 		err := waitAWReady(context, aw)
 

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -34,7 +34,22 @@ var _ = Describe("Predicates E2E Test", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	//NOTE: Recommend this test not to be the last test in the test suite it may pass
+	//      may pass the local test but may cause controller to fail which is not
+	//      part of this test's validation.
+
 	It("Create AppWrapper - PodTemplate Only - 2 Pods", func() {
+		context := initTestContext()
+		defer cleanupTestContext(context)
+
+		aw := createPodTemplateAW(context,"aw-podtemplate-2")
+
+		err := waitAWReady(context, aw)
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Create AppWrapper - Bad PodTemplate", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)
 
@@ -44,7 +59,8 @@ var _ = Describe("Predicates E2E Test", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 	})
-/*
+
+	/*
 	It("Gang scheduling", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -33,6 +33,17 @@ var _ = Describe("Predicates E2E Test", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("Create AppWrapper - PodTemplate Only - 2 Pods", func() {
+		context := initTestContext()
+		defer cleanupTestContext(context)
+
+		aw := createPodTemplateAW(context,"aw-podtemplate-2")
+
+		err := waitAWReady(context, aw)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
 /*
 	It("Gang scheduling", func() {
 		context := initTestContext()

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -512,7 +512,7 @@ func createDeploymentAW(context *context, name string) *arbv1.AppWrapper {
 //      may pass the local test but may cause controller to fail which is not
 //      part of this test's validation.
 func createBadPodTemplateAW(context *context, name string) *arbv1.AppWrapper {
-	rb := []byte(`{"apiVersion": v1"
+	rb := []byte(`{"apiVersion": "v1"
 		"kind": "Pod"
 		"metadata": {
 			"labels": {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -512,8 +512,8 @@ func createDeploymentAW(context *context, name string) *arbv1.AppWrapper {
 //      may pass the local test but may cause controller to fail which is not
 //      part of this test's validation.
 func createBadPodTemplateAW(context *context, name string) *arbv1.AppWrapper {
-	rb := []byte(`{"apiVersion": "v1"
-		"kind": "Pod"
+	rb := []byte(`{"apiVersion": "v1",
+		"kind": "Pod",
 		"metadata": {
 			"labels": {
 				"app": "nginx"


### PR DESCRIPTION
This is a fix to the panic error by the controller when an invalid pod template is submitted.  The controller now handles the casting error and logs the related error.  Two additional e2e test we also added 1 podtemplate creation success and 1 podtemplate failure.