### PR TITLE
Force specific version of Helm for e2e test.

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -126,7 +126,7 @@ function kube-test-env-up {
     curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > install-helm.sh
     chmod u+x install-helm.sh
     cat install-helm.sh
-    ./install-helm.sh
+    ./install-helm.sh --version v2.16.3
 
     # Start Helm Server
     echo "Installing Helm Server..."
@@ -149,6 +149,7 @@ function kube-test-env-up {
 
     # start mcad controller
     echo "Starting MCAD Controller..."
+    echo "helm install kube-arbitrator namespace kube-system wait set resources.requests.cpu=1000m set resources.requests.memory=1024Mi set resources.limits.cpu=1000m set resources.limits.memory=1024Mi set image.repository=$IMAGE_REPOSITORY_MCAD set image.tag=$IMAGE_TAG_MCAD set image.pullPolicy=$MCAD_IMAGE_PULL_POLICY debug"
     helm install kube-arbitrator --namespace kube-system --wait --set resources.requests.cpu=1000m --set resources.requests.memory=1024Mi --set resources.limits.cpu=1000m --set resources.limits.memory=1024Mi --set image.repository=$IMAGE_REPOSITORY_MCAD --set image.tag=$IMAGE_TAG_MCAD --set image.pullPolicy=$MCAD_IMAGE_PULL_POLICY --debug
 
     sleep 10


### PR DESCRIPTION
Latest version of Helm breaks the e2e test.  Setting Helm version to last known working version.

Signed-off-by: Diana Arroyo <darroyo@us.ibm.com>