### PR TITLE
new QPS=100 Burst=200, comment out queuejobctrl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR=_output/bin
-RELEASE_VER=v1.18
+RELEASE_VER=v1.19
 CURRENT_DIR=$(shell pwd)
 #MCAD_REGISTRY=$(shell docker ps --filter name=mcad-registry | grep -v NAME)
 #LOCAL_HOST_NAME=localhost

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -43,8 +43,6 @@ func Run(opt *options.ServerOption) error {
 
 	config.QPS   = 100.0
 	config.Burst = 200.0
-//	queuejobctrl := queuejob.NewQueueJobController(config)
-//	queuejobctrl.Run(neverStop)
 
 	jobctrl := queuejob.NewJobController(config, opt.SchedulerName, opt.Dispatcher, opt.AgentConfigs)
 	if jobctrl ==nil {

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -41,8 +41,10 @@ func Run(opt *options.ServerOption) error {
 
 	neverStop := make(chan struct{})
 
-	queuejobctrl := queuejob.NewQueueJobController(config)
-	queuejobctrl.Run(neverStop)
+	config.QPS   = 100.0
+	config.Burst = 200.0
+//	queuejobctrl := queuejob.NewQueueJobController(config)
+//	queuejobctrl.Run(neverStop)
 
 	jobctrl := queuejob.NewJobController(config, opt.SchedulerName, opt.Dispatcher, opt.AgentConfigs)
 	if jobctrl ==nil {


### PR DESCRIPTION
Set configuration parameter: config.QPS=100, config.Burst=200.  The default client side throttle setting of config.QPS=5, config.Burst=5 from client-go is too low.

Also comment out queuejobctrl related unused legacy code.  Please let me know if they are better deleted rather than commented out.