### PR TITLE
New server option passing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR=_output/bin
-RELEASE_VER=v1.19
+RELEASE_VER=v1.20
 CURRENT_DIR=$(shell pwd)
 #MCAD_REGISTRY=$(shell docker ps --filter name=mcad-registry | grep -v NAME)
 #LOCAL_HOST_NAME=localhost

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -44,7 +44,7 @@ func Run(opt *options.ServerOption) error {
 	config.QPS   = 100.0
 	config.Burst = 200.0
 
-	jobctrl := queuejob.NewJobController(config, opt.SchedulerName, opt.Dispatcher, opt.AgentConfigs)
+	jobctrl := queuejob.NewJobController(config, opt)
 	if jobctrl ==nil {
 		return nil
 	}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -84,6 +84,7 @@ var controllerKind = arbv1.SchemeGroupVersion.WithKind("AppWrapper")
 type XController struct {
 	config           *rest.Config
 	serverOption     *options.ServerOption
+
 	queueJobInformer informersv1.AppWrapperInformer
 	// resources registered for the AppWrapper
 	qjobRegisteredResources queuejobresources.RegisteredResources
@@ -181,16 +182,16 @@ func GetQueueJobKey(obj interface{}) (string, error) {
 //NewJobController create new AppWrapper Controller
 func NewJobController(config *rest.Config, serverOption *options.ServerOption) *XController {
 	cc := &XController{
-		config:				config,
-		clients:			kubernetes.NewForConfigOrDie(config),
+		config:			config,
+		serverOption:		serverOption,
+		clients:		kubernetes.NewForConfigOrDie(config),
 		arbclients:  		clientset.NewForConfigOrDie(config),
 		eventQueue:  		cache.NewFIFO(GetQueueJobKey),
 		agentEventQueue:	cache.NewFIFO(GetQueueJobKey),
-		initQueue:	 		cache.NewFIFO(GetQueueJobKey),
+		initQueue: 		cache.NewFIFO(GetQueueJobKey),
 		updateQueue:		cache.NewFIFO(GetQueueJobKey),
-		qjqueue:			NewSchedulingQueue(),
-		cache: 				clusterstatecache.New(config),
-		serverOption:		serverOption,
+		qjqueue:		NewSchedulingQueue(),
+		cache: 			clusterstatecache.New(config),
 	}
 	cc.metricsAdapter =  adapter.New(config, cc.cache)
 

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -83,7 +83,7 @@ var controllerKind = arbv1.SchemeGroupVersion.WithKind("AppWrapper")
 //XController the AppWrapper Controller type
 type XController struct {
 	config           *rest.Config
-	serverOption *options.ServerOption
+	serverOption     *options.ServerOption
 	queueJobInformer informersv1.AppWrapperInformer
 	// resources registered for the AppWrapper
 	qjobRegisteredResources queuejobresources.RegisteredResources


### PR DESCRIPTION
Pass *options.ServerOption to NewJobController function, instead of passing SchedulerName, Dispatcher, AgentConfigs by value.

Fix cosmetic spacing in NewJobController.

