### PR TITLE
Dynamic priority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR=_output/bin
-RELEASE_VER=v1.23
+RELEASE_VER=v1.24
 CURRENT_DIR=$(shell pwd)
 #MCAD_REGISTRY=$(shell docker ps --filter name=mcad-registry | grep -v NAME)
 #LOCAL_HOST_NAME=localhost

--- a/deployment/kube-arbitrator/templates/deployment.yaml
+++ b/deployment/kube-arbitrator/templates/deployment.yaml
@@ -321,7 +321,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["mcad-controller"]
-        args: ["--v", "4", "--logtostderr", "--dynamicpriority=true"]
+        args: ["--v", "4", "--logtostderr"]
 #        args: ["--v", "10", "--logtostderr", "--secure-port=6443"]
         ports:
         - containerPort: 6443

--- a/deployment/kube-arbitrator/templates/deployment.yaml
+++ b/deployment/kube-arbitrator/templates/deployment.yaml
@@ -321,7 +321,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["mcad-controller"]
-        args: ["--v", "4", "--logtostderr"]
+        args: ["--v", "4", "--logtostderr", "--dynamicpriority=true"]
 #        args: ["--v", "10", "--logtostderr", "--secure-port=6443"]
         ports:
         - containerPort: 6443

--- a/pkg/apis/controller/v1alpha1/appwrapper.go
+++ b/pkg/apis/controller/v1alpha1/appwrapper.go
@@ -152,7 +152,7 @@ type AppWrapperStatus struct {
 	// State of QueueJob - Init, Queueing, HeadOfLine, Rejoining, ...
 	QueueJobState QueueJobState `json:"queuejobstate,omitempty"`
 
-	// Timestamp when controller first sees QueueJob (by Informer)
+	// Microsecond level timestamp when controller first sees QueueJob (by Informer)
 	ControllerFirstTimestamp metav1.MicroTime `json:"controllerfirsttimestamp,omitempty"`
 
 	// Tell Informer to ignore this update message (do not generate a controller event)

--- a/pkg/apis/controller/v1alpha1/appwrapper.go
+++ b/pkg/apis/controller/v1alpha1/appwrapper.go
@@ -153,7 +153,7 @@ type AppWrapperStatus struct {
 	QueueJobState QueueJobState `json:"queuejobstate,omitempty"`
 
 	// Timestamp when controller first sees QueueJob (by Informer)
-	ControllerFirstTimestamp metav1.Time `json:"controllerfirsttimestamp,omitempty"`
+	ControllerFirstTimestamp metav1.MicroTime `json:"controllerfirsttimestamp,omitempty"`
 
 	// Tell Informer to ignore this update message (do not generate a controller event)
 	FilterIgnore bool `json:"filterignore,omitempty"`

--- a/pkg/apis/controller/v1alpha1/appwrapper.go
+++ b/pkg/apis/controller/v1alpha1/appwrapper.go
@@ -47,7 +47,7 @@ type AppWrapperList struct {
 
 // AppWrapperSpec describes how the App Wrapper will look like.
 type AppWrapperSpec struct {
-	Priority      int                    `json:"priority,omitempty"`
+	Priority      float64                `json:"priority,omitempty"`
 	PrioritySlope float64                `json:"priorityslope,omitempty"`
 	Service       AppWrapperService      `json:"service"`
 	AggrResources AppWrapperResourceList `json:"resources"`

--- a/pkg/controller/clusterstate/cache/cache.go
+++ b/pkg/controller/clusterstate/cache/cache.go
@@ -334,7 +334,8 @@ func (sc *ClusterStateCache) Snapshot() *api.ClusterInfo {
 	for _, value := range sc.Jobs {
 		// If no scheduling spec, does not handle it.
 		if value.SchedSpec == nil && value.PDB == nil {
-			glog.V(3).Infof("The scheduling spec of Job <%v> is nil, ignore it.", value.UID)
+			// Jobs.Tasks are more recognizable than Jobs.UID
+			glog.V(3).Infof("The scheduling spec of Job <%v> with tasks <%+v> is nil, ignore it.", value.UID, value.Tasks)
 			continue
 		}
 

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -554,7 +554,7 @@ func (qjm *XController) ScheduleNext() {
 	// amount of resources asked by the job
 	qj, err := qjm.qjqueue.Pop()
 	if err != nil {
-		glog.V(4).Infof("[ScheduleNext] Cannot pop QueueJob from qjqueue! err=%#v")
+		glog.V(4).Infof("[ScheduleNext] Cannot pop QueueJob from qjqueue! err=%#v", err)
 		return // Try to pop qjqueue again
 	} else {
 		glog.V(4).Infof("[ScheduleNext] activeQ.Pop %s *Delay=%.6f seconds RemainingLength=%d &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.Length(), qj, qj.ResourceVersion, qj.Status)
@@ -592,7 +592,7 @@ func (qjm *XController) ScheduleNext() {
 		// Retrive HeadOfLine after priority update
 		qj, err = qjm.qjqueue.Pop()
 		if err != nil {
-			glog.V(4).Infof("[ScheduleNext] Cannot pop QueueJob from qjqueue! err=%#v")
+			glog.V(4).Infof("[ScheduleNext] Cannot pop QueueJob from qjqueue! err=%#v", err)
 		} else {
 			glog.V(4).Infof("[ScheduleNext] activeQ.Pop_afterPriorityUpdate %s *Delay=%.6f seconds RemainingLength=%d &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.Length(), qj, qj.ResourceVersion, qj.Status)
 		}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -929,6 +929,12 @@ func (cc *XController) syncQueueJob(qj *arbv1.AppWrapper) error {
 		// we call sync for each controller
 		// update pods running, pending,...
 		cc.qjobResControls[arbv1.ResourceTypePod].UpdateQueueJobStatus(qj)
+
+		if (qj.Status.Running > 0) {  // set QueueJobStateRunning if at least one resource running
+			qj.Status.QueueJobState = arbv1.QueueJobStateRunning
+			qj.Status.FilterIgnore = true  // Update QueueJobStateRunning
+			cc.updateEtcd(qj, "[syncQueueJob]setRunning")
+		}
 	}
 
 	return cc.manageQueueJob(qj)

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -579,13 +579,14 @@ func (qjm *XController) ScheduleNext() {
 			qjm.qjqueue.AddIfNotPresent(qjtemp.(*arbv1.AppWrapper))
 		}
 		// Print qjqueue.ativeQ for debugging
-		pq := qjm.qjqueue.(*PriorityQueue)
-		if qjm.qjqueue.Length() > 0 {
-			items := pq.activeQ.data.items
-			for key, element := range items {
-				qjtemp := element.obj.(*arbv1.AppWrapper)
-				glog.V(10).Infof("[ScheduleNext] AfterCalc: qjqLength=%d Key=%s index=%d Priority=%.1f SystemPriority=%.1f QueueJobState=%s",
-					qjm.qjqueue.Length(), key, element.index, qjtemp.Spec.Priority, qjtemp.Status.SystemPriority, qjtemp.Status.QueueJobState)
+		if glog.V(10) {
+			pq := qjm.qjqueue.(*PriorityQueue)
+			if qjm.qjqueue.Length() > 0 {
+				for key, element := range pq.activeQ.data.items {
+					qjtemp := element.obj.(*arbv1.AppWrapper)
+					glog.V(10).Infof("[ScheduleNext] AfterCalc: qjqLength=%d Key=%s index=%d Priority=%.1f SystemPriority=%.1f QueueJobState=%s",
+						qjm.qjqueue.Length(), key, element.index, qjtemp.Spec.Priority, qjtemp.Status.SystemPriority, qjtemp.Status.QueueJobState)
+				}
 			}
 		}
 

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -507,7 +507,7 @@ func (qjm *XController) getAggregatedAvailableResourcesPriority(targetpr float64
 					for _, resctrl := range qjm.qjobResControls {
 						qjv := resctrl.GetAggregatedResources(value)
 						pending = pending.Add(qjv)
-						glog.V(10).Infof("[getAggAvaiResPri] Subtract all resources for job %s which can-run is set to: %v and status set to: %s but no pod counts in the state have been defined.", value.Name, value.Status.CanRun, value.Status.State)
+						glog.V(10).Infof("[getAggAvaiResPri] Subtract all resources %+v in resctrlType=%T for job %s which can-run is set to: %v and status set to: %s but no pod counts in the state have been defined.", qjv, resctrl, value.Name, value.Status.CanRun, value.Status.State)
 					}
 				}
 			}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -569,8 +569,6 @@ func (qjm *XController) ScheduleNext() {
 		for qjm.qjqueue.Length() > 0 {
 			qjtemp, _ := qjm.qjqueue.Pop()
 			qjtemp.Status.SystemPriority = qjtemp.Spec.Priority + qjtemp.Spec.PrioritySlope * (time.Now().Sub(qjtemp.Status.ControllerFirstTimestamp.Time)).Seconds()
-//			qjtemp.Status.FilterIgnore = true   // update SystemPriority only
-//			qjm.updateEtcd(qjtemp, "[ScheduleNext]updateSystemPriority")
 			tempQ.Add(qjtemp)
 		}
 		// move AppWrappers back to activeQ and sort based on SystemPriority

--- a/pkg/controller/queuejob/scheduling_queue.go
+++ b/pkg/controller/queuejob/scheduling_queue.go
@@ -98,7 +98,7 @@ var _ = SchedulingQueue(&PriorityQueue{})
 
 func NewPriorityQueue() *PriorityQueue {
 	pq := &PriorityQueue{
-		activeQ:        newHeap(cache.MetaNamespaceKeyFunc, HigherPriorityQJ),
+		activeQ:        newHeap(cache.MetaNamespaceKeyFunc, HigherSystemPriorityQJ),
 		unschedulableQ: newUnschedulableQJMap(),
 	}
 	pq.cond.L = &pq.lock

--- a/pkg/controller/queuejob/utils.go
+++ b/pkg/controller/queuejob/utils.go
@@ -35,6 +35,10 @@ func HigherPriorityQJ(qj1, qj2 interface{} ) bool {
 	return (qj1.(*arbv1.AppWrapper).Spec.Priority > qj2.(*arbv1.AppWrapper).Spec.Priority)
 }
 
+func HigherSystemPriorityQJ(qj1, qj2 interface{} ) bool {
+	return (qj1.(*arbv1.AppWrapper).Status.SystemPriority > qj2.(*arbv1.AppWrapper).Status.SystemPriority)
+}
+
 func generateUUID() string {
 	id := uuid.NewUUID()
 

--- a/pkg/controller/queuejobresources/configmap/configmap.go
+++ b/pkg/controller/queuejobresources/configmap/configmap.go
@@ -132,7 +132,7 @@ func (qjrConfigMap *QueueJobResConfigMap) deleteConfigMap(obj interface{}) {
 }
 
 
-func (qjrConfigMap *QueueJobResConfigMap) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrConfigMap *QueueJobResConfigMap) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/deployment/deployment.go
+++ b/pkg/controller/queuejobresources/deployment/deployment.go
@@ -274,10 +274,10 @@ func (qjrDeployment *QueueJobResDeployment) SyncQueueJob(queuejob *arbv1.AppWrap
 			deploymentInQjr.Labels[k] = v
 		}
 		deploymentInQjr.Labels[queueJobName] = queuejob.Name
-    if deploymentInQjr.Spec.Template.Labels == nil {
-            deploymentInQjr.Labels = map[string]string{}
-    }
-    deploymentInQjr.Spec.Template.Labels[queueJobName] = queuejob.Name
+		if deploymentInQjr.Spec.Template.Labels == nil {
+			deploymentInQjr.Labels = map[string]string{}
+		}
+		deploymentInQjr.Spec.Template.Labels[queueJobName] = queuejob.Name
 
 		wait := sync.WaitGroup{}
 		wait.Add(int(diff))

--- a/pkg/controller/queuejobresources/deployment/deployment.go
+++ b/pkg/controller/queuejobresources/deployment/deployment.go
@@ -138,12 +138,12 @@ func (qjrDeployment *QueueJobResDeployment) GetAggregatedResources(job *arbv1.Ap
 	return total
 }
 
-func (qjrDeployment *QueueJobResDeployment) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrDeployment *QueueJobResDeployment) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         if job.Spec.AggrResources.Items != nil {
             //calculate scaling
             for _, ar := range job.Spec.AggrResources.Items {
-                  if ar.Priority < float64(priority) {
+                  if ar.Priority < priority {
                         continue
                   }
                   if ar.Type == arbv1.ResourceTypeDeployment {

--- a/pkg/controller/queuejobresources/interfaces.go
+++ b/pkg/controller/queuejobresources/interfaces.go
@@ -26,7 +26,7 @@ type Interface interface {
 	SyncQueueJob(queuejob *qjobv1.AppWrapper, qjobRes *qjobv1.AppWrapperResource) error
 	UpdateQueueJobStatus(queuejob *qjobv1.AppWrapper) error
 	GetAggregatedResources(queuejob *qjobv1.AppWrapper) *clusterstateapi.Resource
-	GetAggregatedResourcesByPriority(priority int, queuejob *qjobv1.AppWrapper) *clusterstateapi.Resource
+	GetAggregatedResourcesByPriority(priority float64, queuejob *qjobv1.AppWrapper) *clusterstateapi.Resource
 	//TODO: Add to calculate more accurate partial deployments while job is being realized
 //	GetAggregatedResourcesByPhase(phase v1.PodPhase, queuejob *qjobv1.AppWrapper) *clusterstateapi.Resource
 	Cleanup(queuejob *qjobv1.AppWrapper, qjobRes *qjobv1.AppWrapperResource) error

--- a/pkg/controller/queuejobresources/namespace/namespace.go
+++ b/pkg/controller/queuejobresources/namespace/namespace.go
@@ -131,7 +131,7 @@ func (qjrNamespace *QueueJobResNamespace) deleteNamespace(obj interface{}) {
 }
 
 
-func (qjrNamespace *QueueJobResNamespace) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrNamespace *QueueJobResNamespace) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/networkpolicy/networkpolicy.go
+++ b/pkg/controller/queuejobresources/networkpolicy/networkpolicy.go
@@ -133,7 +133,7 @@ func (qjrNetworkPolicy *QueueJobResNetworkPolicy) deleteNetworkPolicy(obj interf
 }
 
 
-func (qjrNetworkPolicy *QueueJobResNetworkPolicy) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrNetworkPolicy *QueueJobResNetworkPolicy) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/persistentvolume/persistentvolume.go
+++ b/pkg/controller/queuejobresources/persistentvolume/persistentvolume.go
@@ -131,7 +131,7 @@ func (qjrPersistentvolume *QueueJobResPersistentvolume) deletePersistentVolume(o
 }
 
 
-func (qjrPersistentvolume *QueueJobResPersistentvolume) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrPersistentvolume *QueueJobResPersistentvolume) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/pkg/controller/queuejobresources/persistentvolumeclaim/persistentvolumeclaim.go
@@ -130,7 +130,7 @@ func (qjrPersistentVolumeClaim *QueueJobResPersistentVolumeClaim) deletePersiste
 }
 
 
-func (qjrPersistentVolumeClaim *QueueJobResPersistentVolumeClaim) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrPersistentVolumeClaim *QueueJobResPersistentVolumeClaim) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -563,12 +563,12 @@ func (qjrPod *QueueJobResPod) GetAggregatedResources(job *arbv1.AppWrapper) *clu
         return total
 }
 
-func (qjrPod *QueueJobResPod) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrPod *QueueJobResPod) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
 	total := clusterstateapi.EmptyResource()
 	if job.Spec.AggrResources.Items != nil {
 		//calculate scaling
 		for _, ar := range job.Spec.AggrResources.Items {
-			if ar.Priority < float64(priority) {
+			if ar.Priority < priority {
 		  		continue
 		  	}
 

--- a/pkg/controller/queuejobresources/secret/secret.go
+++ b/pkg/controller/queuejobresources/secret/secret.go
@@ -131,7 +131,7 @@ func (qjrSecret *QueueJobResSecret) deleteSecret(obj interface{}) {
 }
 
 
-func (qjrSecret *QueueJobResSecret) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrSecret *QueueJobResSecret) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/service/service.go
+++ b/pkg/controller/queuejobresources/service/service.go
@@ -131,7 +131,7 @@ func (qjrService *QueueJobResService) deleteService(obj interface{}) {
 }
 
 
-func (qjrService *QueueJobResService) GetAggregatedResourcesByPriority(priority int, job *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrService *QueueJobResService) GetAggregatedResourcesByPriority(priority float64, job *arbv1.AppWrapper) *clusterstateapi.Resource {
         total := clusterstateapi.EmptyResource()
         return total
 }

--- a/pkg/controller/queuejobresources/statefulset/statefulset.go
+++ b/pkg/controller/queuejobresources/statefulset/statefulset.go
@@ -140,12 +140,12 @@ func (qjrStatefulSet *QueueJobResStatefulSet) GetAggregatedResources(queueJob *a
 	return total
 }
 
-func (qjrStatefulSet *QueueJobResStatefulSet) GetAggregatedResourcesByPriority(priority int, queueJob *arbv1.AppWrapper) *clusterstateapi.Resource {
+func (qjrStatefulSet *QueueJobResStatefulSet) GetAggregatedResourcesByPriority(priority float64, queueJob *arbv1.AppWrapper) *clusterstateapi.Resource {
 	total := clusterstateapi.EmptyResource()
 	if queueJob.Spec.AggrResources.Items != nil {
 		//calculate scaling
 		for _, ar := range queueJob.Spec.AggrResources.Items {
-			if ar.Priority < float64(priority) {
+			if ar.Priority < priority {
 				continue
 			}
 			if ar.Type == arbv1.ResourceTypeStatefulSet {


### PR DESCRIPTION
1) Add DynamicPriority function. 

  - Modify priority values to float64.

  - Define SystemPriority and HigherSystemPriorityQJ function.

  - Update SystemPriority values if dynamicpriority is set to true.

  - Print contents in qjqueue for glog.V(10).

2) Fix ControllerFirstTimestamp to use metav1.MicroTime

  - Timestamp for objects in program is nanosecond precision until the object is deployed.

  - metav1.MicroTime allows timestamps to maintain microsecond level precision when transmitting to etcd. The 3 extra digits for nanosecond are truncated before transmission.

  - Etcd and local store keeps timestamps with microsecond level precision.

  - After object is deployed, UpdateQueueJobs extracts objects from local store.  ControllerFirstTimestamp will have only microsecond level precision from this time.

3) Print latency in seconds format for easier post analysis of log.

4) Set QueueJobStateRunning if at least one resource is running.  This is in reference to the PodRunning for PodPhase: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L2217

5) Clean up syncQueueJob() to use latest version of qj.