### PR TITLE
Head Of Line Policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR=_output/bin
-RELEASE_VER=v1.24
+RELEASE_VER=v1.25
 CURRENT_DIR=$(shell pwd)
 #MCAD_REGISTRY=$(shell docker ps --filter name=mcad-registry | grep -v NAME)
 #LOCAL_HOST_NAME=localhost

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -701,6 +701,8 @@ func (qjm *XController) backoff(q *arbv1.AppWrapper) {
 	time.Sleep(time.Duration(qjm.serverOption.BackoffTime) * time.Second)
 	qjm.qjqueue.MoveToActiveQueueIfExists(q)
 	q.Status.QueueJobState = arbv1.QueueJobStateQueueing
+	q.Status.FilterIgnore = true  // update QueueJobState only, no work needed
+	qjm.updateEtcd(q, "[backoff] Queueing")
 	glog.V(4).Infof("[backoff] %s activeQ.Add after sleep for %d seconds. activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v", q.Name, qjm.serverOption.BackoffTime, qjm.qjqueue.IfExistActiveQ((q)), qjm.qjqueue.IfExistUnschedulableQ((q)), q, q.ResourceVersion, q.Status)
 }
 

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -677,20 +677,24 @@ func (qjm *XController) ScheduleNext() {
 				// add to eventQueue for dispatching to Etcd
 				if err := qjm.eventQueue.Add(qj); err != nil { // unsuccessful add to eventQueue, add back to activeQ
 					glog.Errorf("[ScheduleNext] Fail to add %s to eventQueue, activeQ.Add_toSchedulingQueue &qj=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
-					qjm.qjqueue.MoveToActiveQueueIfExists(qj)
+//					qjm.qjqueue.MoveToActiveQueueIfExists(qj)
 				} else { // successful add to eventQueue, remove from qjqueue
 					qjm.qjqueue.Delete(qj)
 					forwarded = true
 					glog.V(4).Infof("[ScheduleNext] %s 2Delay=%.6f seconds eventQueue.Add_afterHeadOfLine activeQ=%t, Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
 				}
 			} else {  // Not enough free resources to dispatch HOL
-				qjm.qjqueue.Delete(qj)  // Delete from activeQ in case other threads add it back
-				qjm.qjqueue.AddUnschedulableIfNotPresent(qj)
+//				qjm.qjqueue.Delete(qj)  // Delete from activeQ in case other threads add it back
+//				qjm.qjqueue.AddUnschedulableIfNotPresent(qj)
 				glog.V(10).Infof("[ScheduleNext] HOL Blocking by %s after  addUnsched for %s activeQ=%t Unsched=%t", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj))
-				time.Sleep(time.Second * 1)  // Try to dispatch once per second
+//				time.Sleep(time.Second * 1)  // Try to dispatch once per second
 			}
 			// stop trying to dispatch after HeadOfLineHoldingTime
-			if (time.Now().After(HOLStartTime.Add(time.Duration(qjm.serverOption.HeadOfLineHoldingTime)*time.Second))) { break }
+			if (forwarded || time.Now().After(HOLStartTime.Add(time.Duration(qjm.serverOption.HeadOfLineHoldingTime)*time.Second))) {
+				break
+			} else {
+				time.Sleep(time.Second * 1)  // Try to dispatch once per second
+			}
 		}
 		if !forwarded {
 			// start thread to backoff

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -21,6 +21,7 @@ import (
 	"github.com/IBM/multi-cluster-app-dispatcher/cmd/kar-controllers/app/options"
 	"github.com/golang/glog"
 	"github.com/IBM/multi-cluster-app-dispatcher/pkg/controller/metrics/adapter"
+	"math"
 	"math/rand"
 	"strings"
 
@@ -485,10 +486,10 @@ func (qjm *XController) getAggregatedAvailableResourcesPriority(targetpr float64
 			continue
 		} else if value.Status.State == arbv1.AppWrapperStateEnqueued {
 			// Don't count the resources that can run but not yet realized (job orchestration pending or partially running).
-			glog.V(10).Infof("[getAggAvaiResPri] Subtract all resources for job %s which can-run is set to: %v but state is still pending.", value.Name, value.Status.CanRun)
 			for _, resctrl := range qjm.qjobResControls {
 				qjv := resctrl.GetAggregatedResources(value)
 				pending = pending.Add(qjv)
+				glog.V(10).Infof("[getAggAvaiResPri] Subtract all resources %+v in resctrlType=%T for job %s which can-run is set to: %v but state is still pending.", qjv, resctrl, value.Name, value.Status.CanRun)
 			}
 			continue
 		} else if value.Status.State == arbv1.AppWrapperStateActive {
@@ -497,7 +498,7 @@ func (qjm *XController) getAggregatedAvailableResourcesPriority(targetpr float64
 				for _, resctrl := range qjm.qjobResControls {
 					qjv := resctrl.GetAggregatedResources(value)
 					pending = pending.Add(qjv)
-					glog.V(10).Infof("[getAggAvaiResPri] Subtract all resources for job %s which can-run is set to: %v and status set to: %s but %v pod(s) are pending.", value.Name, value.Status.CanRun, value.Status.State, value.Status.Pending)
+					glog.V(10).Infof("[getAggAvaiResPri] Subtract all resources %+v in resctrlType=%T for job %s which can-run is set to: %v and status set to: %s but %v pod(s) are pending.", qjv, resctrl, value.Name, value.Status.CanRun, value.Status.State, value.Status.Pending)
 				}
 			} else {
 				// TODO: Hack to handle race condition when Running jobs have not yet updated the pod counts
@@ -598,7 +599,10 @@ func (qjm *XController) ScheduleNext() {
 	}
 
 	qj.Status.QueueJobState = arbv1.QueueJobStateHeadOfLine
+	qj.Status.FilterIgnore = true   // update QueueJobState only
+	qjm.updateEtcd(qj, "[ScheduleNext]setHOL")
 	qjm.qjqueue.AddUnschedulableIfNotPresent(qj)  // working on qj, avoid other threads putting it back to activeQ
+	glog.V(10).Infof("[ScheduleNext] after Pop qjqLength=%d qj %s Version=%s activeQ=%t Unsched=%t Status=%+v", qjm.qjqueue.Length(), qj.Name, qj.ResourceVersion, qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj.Status)
 	if(qjm.isDispatcher) {
 		glog.V(2).Infof("[ScheduleNext] [Dispatcher Mode] Dispatch Next QueueJob: %s\n", qj.Name)
 	}else{
@@ -636,40 +640,59 @@ func (qjm *XController) ScheduleNext() {
 	} else {						// Agent Mode
 		aggqj := qjm.GetAggregatedResources(qj)
 
-		resources := qjm.getAggregatedAvailableResourcesPriority(qj.Spec.Priority, qj.Name)
-		glog.V(2).Infof("[ScheduleNext] XQJ %s with resources %v to be scheduled on aggregated idle resources %v", qj.Name, aggqj, resources)
+		// HeadOfLine logic
+		HOLStartTime := time.Now()
+		forwarded := false
+		// Try to forward to eventQueue for at most HeadOfLineHoldingTime
+		for (!forwarded && time.Now().Before(HOLStartTime.Add(time.Duration(qjm.serverOption.HeadOfLineHoldingTime)*time.Second))) {
+			priorityindex := qj.Status.SystemPriority
+			// Support for Non-Preemption
+			if !qjm.serverOption.Preemption     { priorityindex = -math.MaxFloat64 }
+			// Disable Preemption under DynamicPriority.  Comment out if allow DynamicPriority and Preemption at the same time.
+			if qjm.serverOption.DynamicPriority { priorityindex = -math.MaxFloat64 }
+			resources := qjm.getAggregatedAvailableResourcesPriority(priorityindex, qj.Name)
+			glog.V(2).Infof("[ScheduleNext] XQJ %s with resources %v to be scheduled on aggregated idle resources %v", qj.Name, aggqj, resources)
 
-		if aggqj.LessEqual(resources) {
-			// qj is ready to go!
-			apiQueueJob, e := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
-			// apiQueueJob's ControllerFirstTimestamp is only microsecond level instead of nanosecond level
-			if e != nil {
-				return
+			if aggqj.LessEqual(resources) {
+				// qj is ready to go!
+				apiQueueJob, e := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
+				// apiQueueJob's ControllerFirstTimestamp is only microsecond level instead of nanosecond level
+				if e != nil {
+					return
+				}
+				// make sure qj has the latest information
+				if larger(apiQueueJob.ResourceVersion, qj.ResourceVersion) {
+					glog.V(10).Infof("[ScheduleNext] %s found more recent copy from cache          &qj=%p          qj=%+v", qj.Name, qj, qj)
+					glog.V(10).Infof("[ScheduleNext] %s found more recent copy from cache &apiQueueJob=%p apiQueueJob=%+v", apiQueueJob.Name, apiQueueJob, apiQueueJob)
+					apiQueueJob.DeepCopyInto(qj)
+				}
+				desired := int32(0)
+				for i, ar := range qj.Spec.AggrResources.Items {
+					desired += ar.Replicas
+					qj.Spec.AggrResources.Items[i].AllocatedReplicas = ar.Replicas
+				}
+				qj.Status.CanRun = true
+				qj.Status.FilterIgnore = true // update CanRun & Spec.  no need to trigger event
+				qjm.updateEtcd(qj, "[ScheduleNext]setCanRun")
+				// add to eventQueue for dispatching to Etcd
+				if err := qjm.eventQueue.Add(qj); err != nil { // unsuccessful add to eventQueue, add back to activeQ
+					glog.Errorf("[ScheduleNext] Fail to add %s to eventQueue, activeQ.Add_toSchedulingQueue &qj=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
+					qjm.qjqueue.MoveToActiveQueueIfExists(qj)
+				} else { // successful add to eventQueue, remove from qjqueue
+					qjm.qjqueue.Delete(qj)
+					forwarded = true
+					glog.V(4).Infof("[ScheduleNext] %s 2Delay=%.6f seconds eventQueue.Add_afterHeadOfLine activeQ=%t, Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
+				}
+			} else {  // Not enough free resources to dispatch HOL
+				qjm.qjqueue.Delete(qj)  // Delete from activeQ in case other threads add it back
+				qjm.qjqueue.AddUnschedulableIfNotPresent(qj)
+				glog.V(10).Infof("[ScheduleNext] HOL Blocking by %s after  addUnsched for %s activeQ=%t Unsched=%t", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj))
+				time.Sleep(time.Second * 1)  // Try to dispatch once per second
 			}
-			// make sure qj has the latest information
-			if larger(apiQueueJob.ResourceVersion, qj.ResourceVersion) {
-				glog.V(10).Infof("[ScheduleNext] %s found more recent copy from cache          &qj=%p          qj=%+v", qj.Name, qj, qj)
-				glog.V(10).Infof("[ScheduleNext] %s found more recent copy from cache &apiQueueJob=%p apiQueueJob=%+v", apiQueueJob.Name, apiQueueJob, apiQueueJob)
-				apiQueueJob.DeepCopyInto(qj)
-			}
-			desired := int32(0)
-			for i, ar := range qj.Spec.AggrResources.Items {
-				desired += ar.Replicas
-				qj.Spec.AggrResources.Items[i].AllocatedReplicas = ar.Replicas
-			}
-			qj.Status.CanRun = true
-			qj.Status.FilterIgnore = true   // update CanRun & Spec.  no need to trigger event
-			qjm.updateEtcd(qj, "[ScheduleNext]setCanRun")
-			// add to eventQueue for dispatching to Etcd
-			if err := qjm.eventQueue.Add(qj); err != nil {  // unsuccessful add to eventQueue, add back to activeQ
-				glog.Errorf("[ScheduleNext] Fail to add %s to eventQueue, activeQ.Add_toSchedulingQueue &qj=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
-				qjm.qjqueue.MoveToActiveQueueIfExists(qj)
-			} else {  // successful add to eventQueue, remove from qjqueue
-				qjm.qjqueue.Delete(qj)
-				glog.V(4).Infof("[ScheduleNext] %s 2Delay=%.6f seconds eventQueue.Add_afterHeadOfLine activeQ=%t, Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
-			}
-		} else {
+		}
+		if !forwarded {
 			// start thread to backoff
+			glog.V(10).Infof("[ScheduleNext] HOL backoff %s after waiting for %s activeQ=%t Unsched=%t", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj))
 			go qjm.backoff(qj)
 		}
 	}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -644,7 +644,7 @@ func (qjm *XController) ScheduleNext() {
 		HOLStartTime := time.Now()
 		forwarded := false
 		// Try to forward to eventQueue for at most HeadOfLineHoldingTime
-		for (!forwarded && time.Now().Before(HOLStartTime.Add(time.Duration(qjm.serverOption.HeadOfLineHoldingTime)*time.Second))) {
+		for !forwarded {
 			priorityindex := qj.Status.SystemPriority
 			// Support for Non-Preemption
 			if !qjm.serverOption.Preemption     { priorityindex = -math.MaxFloat64 }
@@ -689,6 +689,8 @@ func (qjm *XController) ScheduleNext() {
 				glog.V(10).Infof("[ScheduleNext] HOL Blocking by %s after  addUnsched for %s activeQ=%t Unsched=%t", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj))
 				time.Sleep(time.Second * 1)  // Try to dispatch once per second
 			}
+			// stop trying to dispatch after HeadOfLineHoldingTime
+			if (time.Now().After(HOLStartTime.Add(time.Duration(qjm.serverOption.HeadOfLineHoldingTime)*time.Second))) { break }
 		}
 		if !forwarded {
 			// start thread to backoff

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -682,18 +682,18 @@ func (qjm *XController) ScheduleNext() {
 					forwarded = true
 					glog.V(4).Infof("[ScheduleNext] %s 2Delay=%.6f seconds eventQueue.Add_afterHeadOfLine activeQ=%t, Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
 				}
-			} else {  // Not enough free resources to dispatch HOL
-				glog.V(10).Infof("[ScheduleNext] HOL Blocking by %s after  addUnsched for %s activeQ=%t Unsched=%t", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj))
+			} else { // Not enough free resources to dispatch HOL
+				glog.V(4).Infof("[ScheduleNext] HOL Blocking by %s for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
 			}
 			// stop trying to dispatch after HeadOfLineHoldingTime
 			if (forwarded || time.Now().After(HOLStartTime.Add(time.Duration(qjm.serverOption.HeadOfLineHoldingTime)*time.Second))) {
 				break
-			} else {  // Try to dispatch again after one second
+			} else { // Try to dispatch again after one second
 				time.Sleep(time.Second * 1)
 			}
 		}
 		if !forwarded { // start thread to backoff
-			glog.V(10).Infof("[ScheduleNext] HOL backoff %s after waiting for %s activeQ=%t Unsched=%t", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj))
+			glog.V(4).Infof("[ScheduleNext] HOL backoff %s after waiting for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
 			go qjm.backoff(qj)
 		}
 	}


### PR DESCRIPTION
+ Add Head Of Line Reservation policy.

  - Move HeadOfLine job from activeQ to unschedulableQ in ScheduleNext thread.

  - Other threads will not put job to activeQ if it is already in unschedulableQ.

  - If ScheduleNext thread can not forward job request to eventQueue, then check HeadOfLineHoldingTime to decide whether to try again after 1 second.

  - Reasons for not able to forward job request to eventQueue are:

    1) not enough idle resources;

    2) enough idle resource, but eventQueue.Add failed.

+ Handling of AppWrapper entry point in UpdateQueueJobs().

  - It was observed that UpdateQueueJobs() could be the first to see a new AppWrapper request during heavy load.

+ Improved glog info.