### PR TITLE
Handle cache race cond

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN_DIR=_output/bin
-RELEASE_VER=v1.26
+RELEASE_VER=v1.27
 CURRENT_DIR=$(shell pwd)
 #MCAD_REGISTRY=$(shell docker ps --filter name=mcad-registry | grep -v NAME)
 #LOCAL_HOST_NAME=localhost

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -632,7 +632,20 @@ func (qjm *XController) ScheduleNext() {
 
 	qj.Status.QueueJobState = arbv1.QueueJobStateHeadOfLine
 	qj.Status.FilterIgnore = true   // update QueueJobState only
-	qjm.updateEtcd(qj, "[ScheduleNext]setHOL")
+	apiCacheAWJob, e := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
+	// apiQueueJob's ControllerFirstTimestamp is only microsecond level instead of nanosecond level
+	if e != nil {
+		glog.Errorf("[ScheduleNext] Unable to get AW %s from API cache &aw=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
+		return
+	}
+	// make sure qj has the latest information
+	if larger(apiCacheAWJob.ResourceVersion, qj.ResourceVersion) {
+		glog.V(10).Infof("[ScheduleNext] %s found more recent copy from cache          &qj=%p          qj=%+v", qj.Name, qj, qj)
+		glog.V(10).Infof("[ScheduleNext] %s found more recent copy from cache &apiQueueJob=%p apiQueueJob=%+v", apiCacheAWJob.Name, apiCacheAWJob, apiCacheAWJob)
+		apiCacheAWJob.DeepCopyInto(qj)
+	}
+
+	qjm.updateEtcd(qj, "ScheduleNext - setHOL")
 	qjm.qjqueue.AddUnschedulableIfNotPresent(qj)  // working on qj, avoid other threads putting it back to activeQ
 	glog.V(10).Infof("[ScheduleNext] after Pop qjqLength=%d qj %s Version=%s activeQ=%t Unsched=%t Status=%+v", qjm.qjqueue.Length(), qj.Name, qj.ResourceVersion, qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj.Status)
 	if(qjm.isDispatcher) {
@@ -690,6 +703,7 @@ func (qjm *XController) ScheduleNext() {
 				apiQueueJob, e := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
 				// apiQueueJob's ControllerFirstTimestamp is only microsecond level instead of nanosecond level
 				if e != nil {
+					glog.Errorf("[ScheduleNext] Unable to get AW %s from API cache &aw=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
 					return
 				}
 				// make sure qj has the latest information

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -754,7 +754,7 @@ func (cc *XController) updateEtcd(qj *arbv1.AppWrapper, at string) error {
 	qj.Status.Sender = "before "+ at  // set Sender string to indicate code location
 	qj.Status.Local  = false          // for Informer FilterFunc to pickup
 	if qjj, err := cc.arbclients.ArbV1().AppWrappers(qj.Namespace).Update(qj); err != nil {
-		glog.Errorf("[updateEtcd] Failed to update status of AppWrapper %s, namespace: %s at %s err=%v qj=%+v", qj.Name, qj.Namespace, at, err)
+		glog.Errorf("[updateEtcd] Failed to update status of AppWrapper %s, namespace: %s at %s err=%v", qj.Name, qj.Namespace, at, err)
 		return err
 	} else {  // qjj should be the same as qj except with newer ResourceVersion
 		qj.ResourceVersion = qjj.ResourceVersion  // update new ResourceVersion from etcd

--- a/pkg/controller/queuejob/scheduling_queue.go
+++ b/pkg/controller/queuejob/scheduling_queue.go
@@ -142,14 +142,14 @@ func (p *PriorityQueue) MoveToActiveQueueIfExists(aw *qjobv1.AppWrapper) error {
 	defer p.lock.Unlock()
 	if p.unschedulableQ.Get(aw) != nil {
 		p.unschedulableQ.Delete(aw)
+		err := p.activeQ.AddIfNotPresent(aw)
+		if err != nil {
+			glog.Errorf("[MoveToActiveQueueIfExists] Error adding AW %v to the scheduling queue: %v\n", aw.Name, err)
+		}
+		p.cond.Broadcast()
+		return err
 	}
-	err := p.activeQ.AddIfNotPresent(aw)
-	if err != nil {
-		glog.Errorf("[MoveToActiveQueueIfExists] Error adding AW %v to the scheduling queue: %v\n", aw.Name, err)
-	}
-	p.cond.Broadcast()
-
-	return err
+	return nil
 }
 
 

--- a/pkg/controller/queuejob/scheduling_queue.go
+++ b/pkg/controller/queuejob/scheduling_queue.go
@@ -137,19 +137,19 @@ func (p *PriorityQueue) IfExistUnschedulableQ(qj *qjobv1.AppWrapper) bool {
 }
 
 // Move QJ from unschedulableQ to activeQ if exists
-func (p *PriorityQueue) MoveToActiveQueueIfExists(qj *qjobv1.AppWrapper) error {
+func (p *PriorityQueue) MoveToActiveQueueIfExists(aw *qjobv1.AppWrapper) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	if p.unschedulableQ.Get(qj) != nil {
-		p.unschedulableQ.Delete(qj)
-		err := p.activeQ.Add(qj)
-		if err != nil {
-			glog.Errorf("Error adding QJ %v to the scheduling queue: %v\n", qj.Name, err)
-		}
-		p.cond.Broadcast()
-		return err
+	if p.unschedulableQ.Get(aw) != nil {
+		p.unschedulableQ.Delete(aw)
 	}
-	return nil
+	err := p.activeQ.AddIfNotPresent(aw)
+	if err != nil {
+		glog.Errorf("[MoveToActiveQueueIfExists] Error adding AW %v to the scheduling queue: %v\n", aw.Name, err)
+	}
+	p.cond.Broadcast()
+
+	return err
 }
 
 

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -109,16 +109,18 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		defer cleanupTestContext(context)
 
 		aw := createDeploymentAW(context,"aw-deployment-1")
-
+		fmt.Fprintf(os.Stdout, "[e2e] Awaiting %d pods running for AW %s.\n", aw.Spec.SchedSpec.MinAvailable, aw.Name)
 		err := waitAWPodsReady(context, aw)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Now delete the appwrapper
 		pods := getPodsOfAppWrapper(context, aw)
+		fmt.Fprintf(os.Stdout, "[e2e] Deleting AW %s.\n", aw.Name)
 		err = deleteAppWrapper(context, "aw-deployment-1")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Wait for the pods of the deleted the appwrapper to be destroyed
+		fmt.Fprintf(os.Stdout, "[e2e] Awaiting %d pods to be deleted for AW %s.\n", aw.Spec.SchedSpec.MinAvailable, aw.Name)
 		err= waitAWDeleted(context, aw, pods)
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION
A race condition occurs with the k8s cache of AW objects.  This fix allow a retry of etcd update when this race cond. causes an error during etcd update.