### PR TITLE
Add health probe to controller

### DIFF
--- a/cmd/kar-controllers/app/options/options.go
+++ b/cmd/kar-controllers/app/options/options.go
@@ -17,8 +17,8 @@ limitations under the License.
 package options
 
 import (
-	"k8s.io/klog"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 	"os"
 	"strconv"
 	"strings"
@@ -26,19 +26,20 @@ import (
 
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
-	Master			string
-	Kubeconfig		string
-	SchedulerName 		string
-	Dispatcher		bool
-	AgentConfigs 		string
-	SecurePort		int
-	DynamicPriority		bool  // If DynamicPriority=true then no preemption is allowed by program logic
-	Preemption 		bool  // Preemption is not allowed under DynamicPriority
-	BackoffTime		int   // Number of seconds a job will go away for, if it can not be scheduled.  Default is 20.
+	Master          string
+	Kubeconfig      string
+	SchedulerName   string
+	Dispatcher      bool
+	AgentConfigs    string
+	SecurePort      int
+	DynamicPriority bool // If DynamicPriority=true then no preemption is allowed by program logic
+	Preemption      bool // Preemption is not allowed under DynamicPriority
+	BackoffTime     int  // Number of seconds a job will go away for, if it can not be scheduled.  Default is 20.
 	// Head of line job will not be bumped away for at least HeadOfLineHoldingTime seconds by higher priority jobs.
 	// Default setting to 0 disables this mechanism.
-	HeadOfLineHoldingTime	int
-	QuotaRestURL		string
+	HeadOfLineHoldingTime int
+	QuotaRestURL          string
+	HealthProbeListenAddr string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -55,16 +56,16 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Master, "scheduler", s.SchedulerName, "scheduler name for placing pods")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	fs.BoolVar(&s.Dispatcher,"dispatcher",s.Dispatcher,"set dispather mode(true) or agent mode(false)")
+	fs.BoolVar(&s.Dispatcher, "dispatcher", s.Dispatcher, "set dispather mode(true) or agent mode(false)")
 	fs.StringVar(&s.AgentConfigs, "agentconfigs", s.AgentConfigs, "Paths to agent config file:deploymentName separted by commas(,)")
-	fs.BoolVar(&s.DynamicPriority,"dynamicpriority", s.DynamicPriority,"If true, set controller to use dynamic priority. If false, set controller to use static priority.  Default is false.")
-	fs.BoolVar(&s.Preemption,"preemption", s.Preemption,"Set controller to allow preemption if set to true. Note: when set to true, the Kubernetes Scheduler must be configured to enable preemption.  Default is false.")
-	fs.IntVar(&s.BackoffTime,"backofftime", s.BackoffTime,"Number of seconds a job will go away for, if it can not be scheduled.  Default is 20.")
-	fs.IntVar(&s.HeadOfLineHoldingTime,"headoflineholdingtime", s.HeadOfLineHoldingTime,"Number of seconds a job can stay at the Head Of Line without being bumped.  Default is 0.")
-	fs.StringVar(&s.QuotaRestURL,"quotaURL", s.QuotaRestURL,"URL for ReST quota management.  Default is none.")
-//	fs.IntVar(&s.SecurePort, "secure-port", 6443, "The port on which to serve secured, uthenticated access for metrics.")
+	fs.BoolVar(&s.DynamicPriority, "dynamicpriority", s.DynamicPriority, "If true, set controller to use dynamic priority. If false, set controller to use static priority.  Default is false.")
+	fs.BoolVar(&s.Preemption, "preemption", s.Preemption, "Set controller to allow preemption if set to true. Note: when set to true, the Kubernetes Scheduler must be configured to enable preemption.  Default is false.")
+	fs.IntVar(&s.BackoffTime, "backofftime", s.BackoffTime, "Number of seconds a job will go away for, if it can not be scheduled.  Default is 20.")
+	fs.IntVar(&s.HeadOfLineHoldingTime, "headoflineholdingtime", s.HeadOfLineHoldingTime, "Number of seconds a job can stay at the Head Of Line without being bumped.  Default is 0.")
+	fs.StringVar(&s.QuotaRestURL, "quotaURL", s.QuotaRestURL, "URL for ReST quota management.  Default is none.")
+	//	fs.IntVar(&s.SecurePort, "secure-port", 6443, "The port on which to serve secured, uthenticated access for metrics.")
+	fs.StringVar(&s.HealthProbeListenAddr, "healthProbeListenAddr", ":8081", "Listen address for health probes. Defaults to ':8081'")
 	klog.V(4).Infof("[AddFlags] Controller configuration: %+v", s)
-
 }
 
 func (s *ServerOption) loadDefaultsFromEnvVars() {

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -19,9 +19,11 @@ package app
 import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"net/http"
 
 	"github.com/IBM/multi-cluster-app-dispatcher/cmd/kar-controllers/app/options"
 	"github.com/IBM/multi-cluster-app-dispatcher/pkg/controller/queuejob"
+	"github.com/IBM/multi-cluster-app-dispatcher/pkg/health"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
@@ -41,16 +43,31 @@ func Run(opt *options.ServerOption) error {
 
 	neverStop := make(chan struct{})
 
-	config.QPS   = 100.0
+	config.QPS = 100.0
 	config.Burst = 200.0
 
 	jobctrl := queuejob.NewJobController(config, opt)
-	if jobctrl ==nil {
+	if jobctrl == nil {
 		return nil
 	}
 	jobctrl.Run(neverStop)
 
-	<-neverStop
+	err = listenHealthProbe(opt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Starts the health probe listener
+func listenHealthProbe(opt *options.ServerOption) error {
+	handler := http.NewServeMux()
+	handler.Handle("/healthz", &health.Handler{})
+	err := http.ListenAndServe(opt.HealthProbeListenAddr, handler)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -52,6 +52,7 @@ func Run(opt *options.ServerOption) error {
 	}
 	jobctrl.Run(neverStop)
 
+	// This call is blocking (unless an error occurs) which equates to <-neverStop
 	err = listenHealthProbe(opt)
 	if err != nil {
 		return err

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,13 @@
+package health
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type Handler struct {
+}
+
+func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	fmt.Fprint(resp, "ok")
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,27 @@
+package health
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthProbe(t *testing.T) {
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := Handler{}
+	handler.ServeHTTP(rr, req)
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned unexpected status: %v", status)
+	}
+
+	expected := "ok"
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v expected %v",
+			rr.Body.String(), expected)
+	}
+}


### PR DESCRIPTION
This pull request adds a health probe to the controller which listens on port `8081` by default.

A health probe is necessary to determine whether the current process is currently operational or can be determined to be defunct and should be destroyed and restarted. This probe responds to http get requests on the **/healthz** endpoint and returns a plain response of ok. All other requests on this port will return 404/Not Found. This is added to a new http listener on **8081** because the health probe only needs to be locally accessible, such as within a pod on Kubernetes. It does not need to be exposed externally as a REST API would. For this reason, we use a separate port for http probes vs other http traffic.

This pull request also includes a server option so that a port other than 8081 can be configured as well as a test case.