### PR TITLE
Part 1 of quota library integration.  

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	k8s.io/metrics v0.20.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
-	sigs.k8s.io/yaml v1.2.0 // indirect
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/pkg/controller/quota/quota_manager_interface.go
+++ b/pkg/controller/quota/quota_manager_interface.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package quota
+
+import (
+	arbv1 "github.com/IBM/multi-cluster-app-dispatcher/pkg/apis/controller/v1alpha1"
+	clusterstateapi "github.com/IBM/multi-cluster-app-dispatcher/pkg/controller/clusterstate/api"
+)
+
+type QuotaManagerInterface interface {
+	Fits(aw *arbv1.AppWrapper, resources *clusterstateapi.Resource, proposedPremptions []*arbv1.AppWrapper) (bool, []*arbv1.AppWrapper)
+	Release(aw *arbv1.AppWrapper) bool
+}

--- a/pkg/controller/quota/quotamanager/quota_rest_manager.go
+++ b/pkg/controller/quota/quotamanager/quota_rest_manager.go
@@ -1,3 +1,5 @@
+// +build !private
+
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -14,27 +16,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This file contains structures that implement scheduling queue types.
-// Scheduling queues hold pods waiting to be scheduled. This file has two types
-// of scheduling queue: 1) a FIFO, which is mostly the same as cache.FIFO, 2) a
-// priority queue which has two sub queues. One sub-queue holds pods that are
-// being considered for scheduling. This is called activeQ. Another queue holds
-// pods that are already tried and are determined to be unschedulable. The latter
-// is called unschedulableQ.
-// FIFO is here for flag-gating purposes and allows us to use the traditional
-// scheduling queue when util.PodPriorityEnabled() returns false.
-
 package quotamanager
 
 import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/IBM/multi-cluster-app-dispatcher/cmd/kar-controllers/app/options"
 	arbv1 "github.com/IBM/multi-cluster-app-dispatcher/pkg/apis/controller/v1alpha1"
 	listersv1 "github.com/IBM/multi-cluster-app-dispatcher/pkg/client/listers/controller/v1"
 	clusterstateapi "github.com/IBM/multi-cluster-app-dispatcher/pkg/controller/clusterstate/api"
-	"k8s.io/klog"
+	"github.com/IBM/multi-cluster-app-dispatcher/pkg/controller/quota"
+	"github.com/IBM/multi-cluster-app-dispatcher/pkg/controller/quota/quotamanager/util"
 	"io/ioutil"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 	"math"
 	"net/http"
 	"net/http/httputil"
@@ -43,30 +39,8 @@ import (
 	"time"
 )
 
-const (
-	// AW Namespace used for building unique name for AW job
-	NamespacePrefix string = "NAMESPACE_"
-
-	// AW Name used for building unique name for AW job
-	AppWrapperNamePrefix string = "_AWNAME_"
-)
-var quotaContext 	    = "quota_context"
-
-// QuotaManager is an interface quota management solutions
-type QuotaManager interface {
-	Fits(aw *arbv1.AppWrapper, resources *clusterstateapi.Resource, proposedPremptions []*arbv1.AppWrapper) (bool, []*arbv1.AppWrapper)
-	Release(aw *arbv1.AppWrapper) bool
-}
-
-// PriorityQueue implements a scheduling queue. It is an alternative to FIFO.
-// The head of PriorityQueue is the highest priority pending QJ. This structure
-// has two sub queues. One sub-queue holds QJ that are being considered for
-// scheduling. This is called activeQ and is a Heap. Another queue holds
-// pods that are already tried and are determined to be unschedulable. The latter
-// is called unschedulableQ.
-// Heap is already thread safe, but we need to acquire another lock here to ensure
-// atomicity of operations on the two data structures..
-type ResourcePlanManager struct {
+// QuotaManager implements a QuotaManagerInterface.
+type QuotaManager struct {
 	url 			string
 	appwrapperLister 	listersv1.AppWrapperLister
 	preemptionEnabled 	bool
@@ -78,40 +52,35 @@ type QuotaGroup struct {
 }
 
 type Request struct {
-	Id          string   	  `json:"id"`
-	Groups      []QuotaGroup  `json:"groups"`
-	Demand      []int         `json:"demand"`
-	Priority    int           `json:"priority"`
-	Preemptable bool          `json:"preemptable"`
+	Id          string       `json:"id"`
+	Groups      []QuotaGroup `json:"groups"`
+	Demand      []int        `json:"demand"`
+	Priority    int          `json:"priority"`
+	Preemptable bool         `json:"preemptable"`
 }
 
 type QuotaResponse struct {
-	Id          string   	   `json:"id"`
-	Groups      []QuotaGroup   `json:"groups"`
-	Demand      []int    	   `json:"demand"`
-	Priority    int      	   `json:"priority"`
-	Preemptable bool     	   `json:"preemptable"`
-	PreemptIds  []string 	   `json:"preemptedIds"`
-	CreateDate  string   	   `json:"dateCreated"`
+	Id          string       `json:"id"`
+	Groups      []QuotaGroup `json:"groups"`
+	Demand      []int        `json:"demand"`
+	Priority    int          `json:"priority"`
+	Preemptable bool         `json:"preemptable"`
+	PreemptIds  []string     `json:"preemptedIds"`
+	CreateDate  string       `json:"dateCreated"`
 }
 
 type TreeNode struct {
-	Allocation	string     	`json:"allocation"`
-	Quota		string  	`json:"quota"`
-	Name		string   	`json:"name"`
-	Hard		bool     	`json:"hard"`
-	Children	[]TreeNode   	`json:"children"`
-	Parent 		string 		`json:"parent"`
+	Allocation	string     `json:"allocation"`
+	Quota		string  `json:"quota"`
+	Name		string   `json:"name"`
+	Hard		bool     `json:"hard"`
+	Children	[]TreeNode   `json:"children"`
+	Parent 		string `json:"parent"`
 }
 
-
-// NewQuotaManager initializes a new scheduling queue.
-func NewQuotaManager() QuotaManager {
-		return NewResourcePlanManager( nil,"", false)
-}
 
 // Making sure that PriorityQueue implements SchedulingQueue.
-var _ = QuotaManager(&ResourcePlanManager{})
+var _ = quota.QuotaManagerInterface(&QuotaManager{})
 
 
 func parseId(id string) (string, string) {
@@ -119,10 +88,10 @@ func parseId(id string) (string, string) {
 	n := ""
 
 	// Extract the namespace seperator
-	nspSplit := strings.Split(id, NamespacePrefix)
+	nspSplit := strings.Split(id, util.NamespacePrefix)
 	if len(nspSplit) == 2 {
 		// Extract the appwrapper seperator
-		awnpSplit := strings.Split(nspSplit[1], AppWrapperNamePrefix)
+		awnpSplit := strings.Split(nspSplit[1], util.AppWrapperNamePrefix)
 		if len(awnpSplit) == 2 {
 			// What is left if the namespace value in the first slice
 			if len(awnpSplit[0]) > 0 {
@@ -140,40 +109,47 @@ func parseId(id string) (string, string) {
 func createId(ns string, n string) string {
 	id := ""
 	if len(ns) > 0 && len(n) > 0 {
-		id = fmt.Sprintf("%s%s%s%s", NamespacePrefix, ns, AppWrapperNamePrefix, n)
+		id = fmt.Sprintf("%s%s%s%s", util.NamespacePrefix, ns, util.AppWrapperNamePrefix, n)
 	}
 	return id
 }
 
-func NewResourcePlanManager(awJobLister listersv1.AppWrapperLister, quotaManagerUrl string, preemptionEnabled bool) *ResourcePlanManager {
-	rpm := &ResourcePlanManager{
-		appwrapperLister: awJobLister,
-		url: quotaManagerUrl,
-		preemptionEnabled: preemptionEnabled,
+func NewQuotaManager(awJobLister listersv1.AppWrapperLister, dispatchedAWDemands map[string]*clusterstateapi.Resource,
+				config *rest.Config, serverOptions *options.ServerOption) (*QuotaManager, error) {
+	if serverOptions.QuotaEnabled == false {
+		klog.Infof("[NewQuotaManager] Quota management is not enabled.")
+		return nil, nil
 	}
-	return rpm
+
+	qm := &QuotaManager{
+		appwrapperLister:    awJobLister,
+		url:                 serverOptions.QuotaRestURL,
+		preemptionEnabled:   serverOptions.Preemption,
+	}
+
+	return qm, nil
 }
 
 // Recrusive call to add names of Tree
-func (rpm *ResourcePlanManager) addChildrenNodes(parentNode TreeNode, treeIDs []string) ([]string) {
+func (qm *QuotaManager) addChildrenNodes(parentNode TreeNode, treeIDs []string) ([]string) {
 	if len(parentNode.Children) > 0 {
 		for _, childNode := range parentNode.Children {
 			klog.V(10).Infof("[getQuotaTreeIDs] Quota tree response child node from quota mananger: %s", childNode.Name)
-			treeIDs = rpm.addChildrenNodes(childNode, treeIDs)
+			treeIDs = qm.addChildrenNodes(childNode, treeIDs)
 		}
 	}
 	treeIDs = append(treeIDs, parentNode.Name)
 	return treeIDs
 }
 
-func (rpm *ResourcePlanManager) getQuotaTreeIDs() ([]string) {
+func (qm *QuotaManager) getQuotaTreeIDs() ([]string) {
 	var treeIDs []string
 	// If a url does not exists then assume fits quota
-	if len(rpm.url) < 1 {
+	if len(qm.url) < 1 {
 		return treeIDs
 	}
 
-	uri := rpm.url + "/json"
+	uri := qm.url + "/json"
 
 	klog.V(10).Infof("[getQuotaTreeIDs] Sending GET request to uri: %s", uri)
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
@@ -207,7 +183,7 @@ func (rpm *ResourcePlanManager) getQuotaTreeIDs() ([]string) {
 			// Loop over root nodes of trees and add names of each node in tree.
 			for _, treeroot := range quotaTreesResponse {
 				klog.V(6).Infof("[getQuotaTreeIDs] Quota tree response root node from quota mananger: %s", treeroot.Name)
-				treeIDs = rpm.addChildrenNodes(treeroot, treeIDs)
+				treeIDs = qm.addChildrenNodes(treeroot, treeIDs)
 			}
 		}
 
@@ -228,11 +204,11 @@ func isValidQuota(quotaGroup QuotaGroup, qmTreeIDs []string) bool {
 	return false
 }
 
-func (rpm *ResourcePlanManager) getQuotaDesignation(aw *arbv1.AppWrapper) ([]QuotaGroup) {
+func (qm *QuotaManager) getQuotaDesignation(aw *arbv1.AppWrapper) ([]QuotaGroup) {
 	var groups []QuotaGroup
 
 	// Get list of quota management tree IDs
-	qmTreeIDs := rpm.getQuotaTreeIDs()
+	qmTreeIDs := qm.getQuotaTreeIDs()
 	if len(qmTreeIDs) < 1 {
 		klog.Warningf("[getQuotaDesignation] No valid quota management IDs found for AppWrapper Job: %s/%s",
 									aw.Namespace, aw.Name)
@@ -278,11 +254,11 @@ func (rpm *ResourcePlanManager) getQuotaDesignation(aw *arbv1.AppWrapper) ([]Quo
 	return groups
 }
 
-func (rpm *ResourcePlanManager) Fits(aw *arbv1.AppWrapper, awResDemands *clusterstateapi.Resource,
+func (qm *QuotaManager) Fits(aw *arbv1.AppWrapper, awResDemands *clusterstateapi.Resource,
 					proposedPreemptions []*arbv1.AppWrapper) (bool, []*arbv1.AppWrapper) {
 
 	// Handle uninitialized quota manager
-	if len(rpm.url) <= 0 {
+	if len(qm.url) <= 0 {
 		return true, proposedPreemptions
 	}
 	awId := createId(aw.Namespace, aw.Name)
@@ -291,8 +267,8 @@ func (rpm *ResourcePlanManager) Fits(aw *arbv1.AppWrapper, awResDemands *cluster
 		return false, nil
 	}
 
-	groups := rpm.getQuotaDesignation(aw)
-	preemptable := rpm.preemptionEnabled
+	groups := qm.getQuotaDesignation(aw)
+	preemptable := qm.preemptionEnabled
 	awCPU_Demand := int(math.Trunc(awResDemands.MilliCPU))
 	awMem_Demand := int(math.Trunc(awResDemands.Memory)/1000000)
 	var demand []int
@@ -309,12 +285,12 @@ func (rpm *ResourcePlanManager) Fits(aw *arbv1.AppWrapper, awResDemands *cluster
 
 	doesFit := false
 	// If a url does not exists then assume fits quota
-	if len(rpm.url) < 1 {
-		klog.V(4).Infof("[Fits] No quota manager exists, %+v meets quota by default.", awResDemands)
+	if len(qm.url) < 1 {
+		klog.V(4).Infof("[Fits] No quota manager exists, %#v meets quota by default.", awResDemands)
 		return doesFit, nil
 	}
 
-	uri := rpm.url + "/quota/alloc"
+	uri := qm.url + "/quota/alloc"
 	buf := new(bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(req)
 	if err != nil {
@@ -348,14 +324,14 @@ func (rpm *ResourcePlanManager) Fits(aw *arbv1.AppWrapper, awResDemands *cluster
 		klog.V(4).Infof("[Fits] Response from quota mananger status code: %v", statusCode)
 		if statusCode == 200 {
 			doesFit = true
-			preemptIds = rpm.getAppWrappers(quotaResponse.PreemptIds)
+			preemptIds = qm.getAppWrappers(quotaResponse.PreemptIds)
 		}
 	}
 	return doesFit, preemptIds
 }
 
 
-func  (rpm *ResourcePlanManager) getAppWrappers(preemptIds []string) []*arbv1.AppWrapper{
+func  (qm *QuotaManager) getAppWrappers(preemptIds []string) []*arbv1.AppWrapper{
 	var aws []*arbv1.AppWrapper
 	if len(preemptIds) <= 0 {
 		return nil
@@ -367,7 +343,7 @@ func  (rpm *ResourcePlanManager) getAppWrappers(preemptIds []string) []*arbv1.Ap
 			klog.Errorf("[getAppWrappers] Failed to parse AppWrapper id from quota manager, parse string: %s.  Preemption of this Id will be ignored.", preemptId)
 			continue
 		}
-		aw, e := rpm.appwrapperLister.AppWrappers(awNamespace).Get(awName)
+		aw, e := qm.appwrapperLister.AppWrappers(awNamespace).Get(awName)
 		if e != nil {
 			klog.Errorf("[getAppWrappers] Failed to get AppWrapper from API Cache %s/%s, err=%v.  Preemption of this Id will be ignored.",
 				awNamespace, awName, e)
@@ -382,10 +358,10 @@ func  (rpm *ResourcePlanManager) getAppWrappers(preemptIds []string) []*arbv1.Ap
 	}
 	return aws
 }
-func (rpm *ResourcePlanManager) Release(aw *arbv1.AppWrapper) bool {
+func (qm *QuotaManager) Release(aw *arbv1.AppWrapper) bool {
 
 	// Handle uninitialized quota manager
-	if len(rpm.url) < 0 {
+	if len(qm.url) < 0 {
 		return true
 	}
 
@@ -396,7 +372,7 @@ func (rpm *ResourcePlanManager) Release(aw *arbv1.AppWrapper) bool {
 		return false
 	}
 
-	uri := rpm.url + "/quota/release/" + awId
+	uri := qm.url + "/quota/release/" + awId
 	klog.V(4).Infof("[Release] Sending request to release resources for: %s ", uri)
 
 	// Create client

--- a/pkg/controller/quota/quotamanager/util/utils.go
+++ b/pkg/controller/quota/quotamanager/util/utils.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// AW Namespace used for building unique name for AW job
+	NamespacePrefix string = "NAMESPACE_"
+
+	// AW Name used for building unique name for AW job
+	AppWrapperNamePrefix string = "_AWNAME_"
+)
+
+func ParseId(id string) (string, string) {
+	ns := ""
+	n := ""
+
+	// Extract the namespace seperator
+	nspSplit := strings.Split(id, NamespacePrefix)
+	if len(nspSplit) == 2 {
+		// Extract the appwrapper seperator
+		awnpSplit := strings.Split(nspSplit[1], AppWrapperNamePrefix)
+		if len(awnpSplit) == 2 {
+			// What is left if the namespace value in the first slice
+			if len(awnpSplit[0]) > 0 {
+				ns = awnpSplit[0]
+			}
+			// And the names value in the second slice
+			if len(awnpSplit[1]) > 0 {
+				n = awnpSplit[1]
+			}
+		}
+	}
+	return ns, n
+}
+
+func CreateId(ns string, n string) string {
+	id := ""
+	if len(ns) > 0 && len(n) > 0 {
+		id = fmt.Sprintf("%s%s%s%s", NamespacePrefix, ns, AppWrapperNamePrefix, n)
+	}
+	return id
+}
+


### PR DESCRIPTION
Initial movement of existing files and QuotaEnable flag introduced for server.

This is part 1 of a multi-part integration change.

This PR does not add any of the integration but preps for new folder structure.
It also adds a new flag for the server to enable quota management.
Summary of changes:

modified:   `cmd/kar-controllers/app/options/options.go` _Adds new QuotaEnable flag to server._

        modified:   `go.mod` _Cleanup_

        renamed:    pkg/controller/quota/quota_manager.go -> `pkg/controller/quota/quotamanager/quota_rest_manager.go` _New directory structure need for integration in following PR.  Moved existing code into new directory structure_

        new file:   `pkg/controller/quota/quota_manager_interface.go` _Removed interface definition originally in pkg/controller/quota/quota_manager.go file to separate file_

        new file:   `pkg/controller/quota/quotamanager/util/utils.go`  _Removed common functions originally in pkg/controller/quota/quota_manager.go file to separate file_

        modified:   `pkg/controller/queuejob/queuejob_controller_ex.go ` _Updated controller to reflect new directory structure, renames and utilizing new server QuotaEnable flag._

Signed-off-by: dmatch01 <darroyo@us.ibm.com>