### PR TITLE
feat: update mcad-controller chart for helm3 compatibility

### DIFF
--- a/deployment/mcad-controller/templates/configmap.yaml
+++ b/deployment/mcad-controller/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   QUOTA_ENABLED: {{ .Values.configMap.quotaEnabled }}
   DISPATCHER_MODE: {{ .Values.configMap.dispatcherMode }}
-  DISPATCHER_AGENT_CONFIGS: {{ .Values.configMap.agentConfigs }}
+  {{ if .Values.configMap.agentConfigs }}DISPATCHER_AGENT_CONFIGS: {{ .Values.configMap.agentConfigs }}{{ end }}
   PREEMPTION: {{ .Values.configMap.preemptionEnabled }}
-  QUOTA_REST_URL: {{ .Values.configMap.quotaRestUrl }}
+  {{ if .Values.configMap.quotaRestUrl }}QUOTA_REST_URL: {{ .Values.configMap.quotaRestUrl }}{{ end }}
 #{{ end }}

--- a/deployment/mcad-controller/values.yaml
+++ b/deployment/mcad-controller/values.yaml
@@ -48,7 +48,7 @@ configMap:
   dispatcherMode: '"false"'
   preemptionEnabled: '"false"'
   agentConfigs: ""
-  quoteRestUrl: ""
+  quotaRestUrl: ""
 
 volumes:
   hostPath:


### PR DESCRIPTION
This should also be helm2 compatible, since the changes are tiny. helm3 is more strict w.r.t. `nil` values.

This PR also fixes a typo in the values.yaml (quote -> quota), which was probably masked by helm2's more lax nil enforcement.

Signed-off-by: Nick Mitchell <nickm@us.ibm.com>