### PR TITLE
Changed scripts to detect if 'docker' or 'podman' are installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Check for 'docker' or 'podman'
+ifneq ($(shell command -v 2 docker 2> /dev/null),)
+	DOCKER=docker
+else
+	DOCKER=podman
+endif
+
 BIN_DIR=_output/bin
 CAT_CMD=$(if $(filter $(OS),Windows_NT),type,cat)
 VERSION_FILE=./CONTROLLER_VERSION
@@ -60,7 +67,7 @@ images: verify-tag-name
 	$(info branch: ${GIT_BRANCH})
 	ls -l ${CURRENT_DIR}/_output/bin
 	$(info Build the docker image)
-	docker build --quiet --no-cache --tag mcad-controller:${TAG} -f ${CURRENT_DIR}/deployment/Dockerfile.both  ${CURRENT_DIR}/_output/bin
+	${DOCKER} build --quiet --no-cache --tag mcad-controller:${TAG} -f ${CURRENT_DIR}/deployment/Dockerfile.both  ${CURRENT_DIR}/_output/bin
 
 push-images: verify-tag-name
 ifeq ($(strip $(dockerhub_repository)),)
@@ -69,11 +76,11 @@ ifeq ($(strip $(dockerhub_repository)),)
 	$(info variables do not need to be set for github Travis CICD.)
 else
 	$(info Log into dockerhub)
-	docker login -u ${dockerhub_id} --password ${dockerhub_token}
+	${DOCKER} login -u ${dockerhub_id} --password ${dockerhub_token}
 	$(info Tag the latest image)
-	docker tag mcad-controller:${TAG}  ${dockerhub_repository}/mcad-controller:${TAG}
+	${DOCKER} tag mcad-controller:${TAG}  ${dockerhub_repository}/mcad-controller:${TAG}
 	$(info Push the docker image to registry)
-	docker push ${dockerhub_repository}/mcad-controller:${TAG}
+	${DOCKER} push ${dockerhub_repository}/mcad-controller:${TAG}
 endif
 
 run-test:

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,3 +1,10 @@
+# Check for 'docker' or 'podman'
+ifneq ($(shell command -v 2 docker 2> /dev/null),)
+	DOCKER=docker
+else
+	DOCKER=podman
+endif
+
 .PHONY: check_delete_operator delete_operator create_new_operator build_operator_image push_operator 
 .PHONY: check_delete_csv delete_csv create_new_csv 
 .PHONY: clean_bundle build_operator_bundle_image push_operator_bundle
@@ -36,7 +43,7 @@ build_operator_image:
 	cd ./mcad-operator && operator-sdk-v0.18.1 build --image-build-args --no-cache darroyo/mcad-operator:${OPERATOR_VER}
 
 push_operator: build_operator_image
-	docker push darroyo/mcad-operator:${OPERATOR_VER}
+	${DOCKER} push darroyo/mcad-operator:${OPERATOR_VER}
 
 check_delete_csv:
 	@echo "******************************************************************************************************"
@@ -65,19 +72,19 @@ clean_bundle:
 
 build_operator_bundle_image: clean_bundle
 	cd ./mcad-operator && operator-sdk-v0.18.1 bundle create --generate-only -o ./bundle
-	docker build --no-cache -f ./mcad-operator/bundle.Dockerfile -t darroyo/mcad-operator-bundle:${OPERATOR_VER} ./mcad-operator
+	${DOCKER} build --no-cache -f ./mcad-operator/bundle.Dockerfile -t darroyo/mcad-operator-bundle:${OPERATOR_VER} ./mcad-operator
 
 push_operator_bundle: build_operator_bundle_image
-	docker push darroyo/mcad-operator-bundle:${OPERATOR_VER}
-	operator-sdk-v0.18.1 bundle validate -b docker --verbose  darroyo/mcad-operator-bundle:${OPERATOR_VER}
+	${DOCKER} push darroyo/mcad-operator-bundle:${OPERATOR_VER}
+	operator-sdk-v0.18.1 bundle validate -b ${DOCKER} --verbose  darroyo/mcad-operator-bundle:${OPERATOR_VER}
 
 clean_catalog:
 	if [ -d "./mcad-operator/database" ]; then cd ./mcad-operator && rm -rf database; fi
 	if [ -f "./mcad-operator/catalog.Dockerfile" ]; then cd ./mcad-operator && rm catalog.Dockerfile; fi
 
 build_operator_catalog_image: clean_catalog
-	cd ./mcad-operator && opm-v1.13.8 index add -c docker --bundles darroyo/mcad-operator-bundle:${OPERATOR_VER} --generate -d catalog.Dockerfile
-	docker build --no-cache -f ./mcad-operator/catalog.Dockerfile -t darroyo/mcad-operator-catalog:${OPERATOR_VER} ./mcad-operator
+	cd ./mcad-operator && opm-v1.13.8 index add -c ${DOCKER} --bundles darroyo/mcad-operator-bundle:${OPERATOR_VER} --generate -d catalog.Dockerfile
+	${DOCKER} build --no-cache -f ./mcad-operator/catalog.Dockerfile -t darroyo/mcad-operator-catalog:${OPERATOR_VER} ./mcad-operator
 
 push_operator_catalog: build_operator_catalog_image
-	docker push darroyo/mcad-operator-catalog:${OPERATOR_VER}
+	${DOCKER} push darroyo/mcad-operator-catalog:${OPERATOR_VER}

--- a/deployment/build-private.sh
+++ b/deployment/build-private.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Set container runtime system
+if [ -x "$(command -v docker)" ]; then
+    DOCKER=docker
+else
+    DOCKER=podman
+fi
+
 # Verify paramenter
 if [ "$#" -ne "2" ]
 then
@@ -16,9 +23,9 @@ project_root=$(cd ..; pwd)
 git_path=github.com/IBM/multi-cluster-app-dispatcher
 
 set +x
-echo "docker run  --rm -v $project_root:/go/src/$git_path -d -w /go/src/$git_path/deployment golang:1.16.3-alpine3.13 ./build-inside-container-private.sh"
+echo "$DOCKER run  --rm -v $project_root:/go/src/$git_path -d -w /go/src/$git_path/deployment golang:1.16.3-alpine3.13 ./build-inside-container-private.sh"
 
-container_id=$(docker run  --rm -v "$project_root":/go/src/$git_path -d -w /go/src/$git_path/deployment golang:1.16.3-alpine3.13 ./build-inside-container-private.sh ${GIT_UID} ${GIT_TOKEN})
+container_id=$($DOCKER run --privileged --rm -v "$project_root":/go/src/$git_path -d -w /go/src/$git_path/deployment golang:1.16.3-alpine3.13 ./build-inside-container-private.sh ${GIT_UID} ${GIT_TOKEN})
 
 set -x
-docker logs -f $container_id
+$DOCKER logs -f $container_id


### PR DESCRIPTION
For systems without `docker` installed, like CentOS, this PR changes the executable to `podman` so that the code can be compiled.

Signed-off-by: Pedro D. Bello-Maldonado <metalcycling@gmail.com>