### PR TITLE
AppWrapper requeueing fix when the job is completed

### DIFF
--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -432,7 +432,7 @@ func (qjm *XController) PreemptQueueJobs() {
 		newjob.Status.CanRun = false
 
 		if (aw.Status.Running + aw.Status.Succeeded) < int32(aw.Spec.SchedSpec.MinAvailable) {
-			message = fmt.Sprintf("Insufficient number of Running pods, minimum=%d, running=%v.", aw.Spec.SchedSpec.MinAvailable, aw.Status.Running)
+			message = fmt.Sprintf("Insufficient number of Running and Completed pods, minimum=%d, running=%d, completed=%d.", aw.Spec.SchedSpec.MinAvailable, aw.Status.Running, aw.Status.Succeeded)
 			cond := GenerateAppWrapperCondition(arbv1.AppWrapperCondPreemptCandidate, v1.ConditionTrue, "MinPodsNotRunning", message)
 			newjob.Status.Conditions = append(newjob.Status.Conditions, cond)
 			updateNewJob = newjob.DeepCopy()

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -487,6 +487,29 @@ var _ = Describe("AppWrapper E2E Test", func() {
 
 	})
 
+	It("MCAD Job Completion No-requeue Test", func() {
+		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Completion No-requeue Test - Started.\n")
+		context := initTestContext()
+		var appwrappers []*arbv1.AppWrapper
+		appwrappersPtr := &appwrappers
+		defer cleanupTestObjectsPtr(context, appwrappersPtr)
+
+		aw := createGenericJobAWWithScheduleSpec(context, "aw-test-job-with-scheduling-spec")
+		err1 := waitAWPodsReady(context, aw)
+		Expect(err1).NotTo(HaveOccurred())
+		err2 := waitAWPodsCompleted(context, aw)
+		Expect(err2).NotTo(HaveOccurred())
+
+		// Once pods are completed, we wait for them to see if they change their status to anything BUT "Completed"
+		// which SHOULD NOT happen because the job is done
+		err3 := waitAWPodsNotCompleted(context, aw)
+		Expect(err3).To(HaveOccurred())
+
+		appwrappers = append(appwrappers, aw)
+		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Completion No-requeue Test - Completed.\n")
+
+	})
+
 	It("MCAD Job Large Compute Requirement Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Large Compute Requirement Test - Started.\n")
 		context := initTestContext()


### PR DESCRIPTION
- Fixed issue with AppWrapper being re-queued after it completes. This was happening because at the end of the job, when all the pods are completed, MCAD would see no 'running' pods so it would think the job needs to be re-queued. 
- Added also a fix to prevent MCAD from deleting AppWrappers after the pods or the application is done

Signed-off-by: Pedro D. Bello-Maldonado <metalcycling@gmail.com>